### PR TITLE
do not count a table column as not numeric if it has empty values

### DIFF
--- a/js/datatable.js
+++ b/js/datatable.js
@@ -86,13 +86,13 @@
                 for (var c = 0; c < this.data[0].length; ++c) {
                     var isNumeric = true;
                     for (var i = 0; i < this.data.length; ++i) {
-                        if (!$.isNumeric(this.data[i][c]) && this.data[i][c] != "") {
+                        if (!$.isNumeric(this.data[i][c]) && this.data[i][c] !== "") {
                             isNumeric = false;
                         }
                     }
                     if (isNumeric) {
                         for (var i = 0; i < this.data.length; ++i) {
-                            if (this.data[i][c] != "") {
+                            if (this.data[i][c] !== "") {
                                 this.data[i][c] = parseFloat(this.data[i][c]);
                             }
                         }

--- a/js/datatable.js
+++ b/js/datatable.js
@@ -86,13 +86,15 @@
                 for (var c = 0; c < this.data[0].length; ++c) {
                     var isNumeric = true;
                     for (var i = 0; i < this.data.length; ++i) {
-                        if (!$.isNumeric(this.data[i][c])) {
+                        if (!$.isNumeric(this.data[i][c]) && this.data[i][c] != "") {
                             isNumeric = false;
                         }
                     }
                     if (isNumeric) {
                         for (var i = 0; i < this.data.length; ++i) {
-                            this.data[i][c] = parseFloat(this.data[i][c]);
+                            if (this.data[i][c] != "") {
+                                this.data[i][c] = parseFloat(this.data[i][c]);
+                            }
                         }
                     }
                 }


### PR DESCRIPTION
Right now if I want to sort values in a column that has empty values, e.g. 
```"120", "35", "16.7", "", "73.6"``` 
I get a wrong result: 
```"", "120.0", "16.7", "35.0", "73.6"```
I think many tables in real life have empty values, so it's useful to consider that.